### PR TITLE
[feat] implementar areas management con tabla, modales y notificaciones

### DIFF
--- a/app/dashboard/areas/page.tsx
+++ b/app/dashboard/areas/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import { Area, obtenerAreas } from "@/services/areasService";
+import AreasTable from "@/components/areas/AreasTable";
+import NewAreaModal from "@/components/areas/NewAreaModal";
+import EditAreaModal from "@/components/areas/EditAreaModal";
+import DeleteAreaModal from "@/components/areas/DeleteAreaModal";
+import Toast from "@/components/areas/Toast";
+import ViewAreaModal from "@/components/areas/ViewAreaModal";
+import { ChevronRight, Plus } from "lucide-react";
+
+interface ToastInfo {
+  mensaje: string;
+  tipo: "exito" | "error";
+}
+
+export default function PaginaAreas() {
+  const [areas, setAreas] = useState<Area[]>([]);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastInfo | null>(null);
+
+  // Modales
+  const [areaAVer, setAreaAVer] = useState<Area | null>(null);
+  const [mostrarCrear, setMostrarCrear] = useState(false);
+  const [areaAEditar, setAreaAEditar] = useState<Area | null>(null);
+  const [areaAEliminar, setAreaAEliminar] = useState<Area | null>(null);
+
+  const mostrarToast = (mensaje: string, tipo: "exito" | "error") => {
+    setToast({ mensaje, tipo });
+  };
+
+  const cargarAreas = useCallback(async () => {
+    setCargando(true);
+    try {
+      const datos = await obtenerAreas();
+      setAreas(datos);
+    } catch {
+      setError("No se pudieron cargar las areas.");
+    } finally {
+      setCargando(false);
+    }
+  }, []);
+
+  useEffect(() => { cargarAreas(); }, [cargarAreas]);
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#f4f7f8]">
+      {/* Barra superior con breadcrumb */}
+      <header className="flex items-center justify-between px-6 py-3.5 bg-white border-b border-[#d1dde2] shrink-0">
+        <nav className="flex items-center gap-1.5 text-xs text-[#8aa3ad]">
+          <span className="hover:text-[#203D47] cursor-pointer transition-colors">Dashboard</span>
+          <ChevronRight size={12} className="text-[#c5d5db]" />
+          <span className="hover:text-[#203D47] cursor-pointer transition-colors">Estructura Organizacional</span>
+          <ChevronRight size={12} className="text-[#c5d5db]" />
+          <span className="text-[#0F1819] font-semibold">Areas</span>
+        </nav>
+      </header>
+
+      {/* Contenido principal */}
+      <main className="flex-1 px-6 py-6 overflow-auto">
+        {/* Titulo y boton */}
+        <div className="flex items-start justify-between mb-6">
+          <div>
+            <h1 className="text-xl font-bold text-[#0F1819]">Gestion de Areas</h1>
+            <p className="text-sm text-[#8aa3ad] mt-0.5">
+              Define y administra los departamentos y unidades de negocio de la organizacion.
+            </p>
+          </div>
+          <button
+            onClick={() => setMostrarCrear(true)}
+            className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-400 text-white text-sm font-semibold px-4 py-2.5 rounded-xl transition-colors shrink-0"
+          >
+            <Plus size={15} />
+            Nueva Area
+          </button>
+        </div>
+
+        {cargando && (
+          <div className="flex items-center justify-center py-20">
+            <div className="flex flex-col items-center gap-3">
+              <div className="w-8 h-8 rounded-full border-2 border-[#203D47] border-t-emerald-400 animate-spin" />
+              <span className="text-xs text-[#8aa3ad]">Cargando areas...</span>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-white rounded-xl px-6 py-4 border border-rose-200 text-sm text-rose-500">
+            {error}
+          </div>
+        )}
+
+        {!cargando && !error && (
+          <AreasTable
+            areas={areas}
+            onVer={(area) => setAreaAVer(area)}
+            onEditar={(area) => setAreaAEditar(area)}
+            onEliminar={(id) => {
+              const area = areas.find((a) => a.id === id);
+              if (area) setAreaAEliminar(area);
+            }}
+          />
+        )}
+      </main>
+
+      {/* Modal — Ver detalles */}
+      {areaAVer && (
+        <ViewAreaModal
+          area={areaAVer}
+          onCerrar={() => setAreaAVer(null)}
+        />
+      )}
+
+      {/* Modal — Crear area */}
+      {mostrarCrear && (
+        <NewAreaModal
+          onCerrar={() => setMostrarCrear(false)}
+          onCreada={async () => {
+            setMostrarCrear(false);
+            await cargarAreas();
+            mostrarToast("Area creada con exito", "exito");
+          }}
+        />
+      )}
+
+      {/* Modal — Editar area */}
+      {areaAEditar && (
+        <EditAreaModal
+          area={areaAEditar}
+          todasLasAreas={areas}
+          onCerrar={() => setAreaAEditar(null)}
+          onEditada={async () => {
+            setAreaAEditar(null);
+            await cargarAreas();
+            mostrarToast("Area editada con exito", "exito");
+          }}
+        />
+      )}
+
+      {/* Modal — Eliminar area */}
+      {areaAEliminar && (
+        <DeleteAreaModal
+          area={areaAEliminar}
+          onCerrar={() => setAreaAEliminar(null)}
+          onEliminada={async () => {
+            setAreaAEliminar(null);
+            await cargarAreas();
+            mostrarToast("Area eliminada con exito", "exito");
+          }}
+        />
+      )}
+
+      {/* Toast de notificacion */}
+      {toast && (
+        <Toast
+          mensaje={toast.mensaje}
+          tipo={toast.tipo}
+          onCerrar={() => setToast(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-// components/Sidebar.tsx
-
 import React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";

--- a/components/areas/AreaRow.tsx
+++ b/components/areas/AreaRow.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+import { Area } from "@/services/areasService";
+import { Eye, Pencil, Trash2 } from "lucide-react";
+
+interface AreaRowProps {
+  area: Area;
+  onVer: (area: Area) => void;
+  onEditar: (area: Area) => void;
+  onEliminar: (id: string) => void;
+}
+
+const BADGE_ESTADO: Record<string, string> = {
+  ACTIVO:     "bg-emerald-100 text-emerald-700",
+  INACTIVO:   "bg-slate-100 text-slate-500",
+  EN_REVISION:"bg-amber-100 text-amber-700",
+};
+
+const ETIQUETA_ESTADO: Record<string, string> = {
+  ACTIVO:     "Activo",
+  INACTIVO:   "Inactivo",
+  EN_REVISION:"En revision",
+};
+
+export default function AreaRow({ area, onVer, onEditar, onEliminar }: AreaRowProps) {
+  return (
+    <tr className="border-b border-[#f0f4f5] hover:bg-[#f8fafb] transition-colors">
+      {/* Nombre del area */}
+      <td className="px-5 py-3.5">
+        <div className="flex items-center gap-3">
+          <div
+            className="w-7 h-7 rounded-lg flex items-center justify-center shrink-0"
+            style={{ backgroundColor: area.color + "22" }}
+          >
+            <span
+              className="w-3 h-3 rounded-full"
+              style={{ backgroundColor: area.color }}
+            />
+          </div>
+          <span className="text-sm font-medium text-[#0F1819]">{area.nombre}</span>
+        </div>
+      </td>
+
+      {/* Descripcion */}
+      <td className="px-5 py-3.5">
+        <span className="text-sm text-[#8aa3ad] truncate max-w-[280px] block">
+          {area.descripcion}
+        </span>
+      </td>
+
+      {/* Posiciones */}
+      <td className="px-5 py-3.5">
+        <span className="text-sm text-[#0F1819] font-medium">{area.posiciones}</span>
+      </td>
+
+      {/* Estado */}
+      <td className="px-5 py-3.5">
+        <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${BADGE_ESTADO[area.estado]}`}>
+          {ETIQUETA_ESTADO[area.estado]}
+        </span>
+      </td>
+
+      {/* Acciones */}
+      <td className="px-5 py-3.5">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => onVer(area)}
+            title="Ver detalles"
+            className="p-1.5 text-[#8aa3ad] hover:text-[#203D47] hover:bg-[#ECEFF1] rounded-lg transition-colors"
+          >
+            <Eye size={15} />
+          </button>
+          <button
+            onClick={() => onEditar(area)}
+            title="Editar area"
+            className="p-1.5 text-[#8aa3ad] hover:text-[#203D47] hover:bg-[#ECEFF1] rounded-lg transition-colors"
+          >
+            <Pencil size={15} />
+          </button>
+          <button
+            onClick={() => onEliminar(area.id)}
+            title="Eliminar area"
+            className="p-1.5 text-[#8aa3ad] hover:text-rose-500 hover:bg-rose-50 rounded-lg transition-colors"
+          >
+            <Trash2 size={15} />
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/components/areas/AreasTable.tsx
+++ b/components/areas/AreasTable.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import React, { useState } from "react";
+import { Area } from "@/services/areasService";
+import AreaRow from "./AreaRow";
+import { Search, Filter, Download } from "lucide-react";
+
+interface AreasTableProps {
+  areas: Area[];
+  onVer: (area: Area) => void;
+  onEditar: (area: Area) => void;
+  onEliminar: (id: string) => void;
+}
+
+const ITEMS_POR_PAGINA = 6;
+
+export default function AreasTable({ areas, onVer, onEditar, onEliminar }: AreasTableProps) {
+  const [busqueda, setBusqueda] = useState("");
+  const [paginaActual, setPaginaActual] = useState(1);
+
+  // Filtrar por busqueda
+  const areasFiltradas = areas.filter(
+    (a) =>
+      a.nombre.toLowerCase().includes(busqueda.toLowerCase()) ||
+      a.descripcion.toLowerCase().includes(busqueda.toLowerCase())
+  );
+
+  // Paginacion
+  const totalPaginas = Math.ceil(areasFiltradas.length / ITEMS_POR_PAGINA);
+  const inicio = (paginaActual - 1) * ITEMS_POR_PAGINA;
+  const areasPagina = areasFiltradas.slice(inicio, inicio + ITEMS_POR_PAGINA);
+
+  const irAPagina = (pagina: number) => {
+    if (pagina >= 1 && pagina <= totalPaginas) setPaginaActual(pagina);
+  };
+
+  return (
+    <div className="bg-white rounded-2xl border border-[#e8eef0] overflow-hidden">
+      {/* Barra de busqueda y filtros */}
+      <div className="flex items-center gap-3 px-5 py-4 border-b border-[#f0f4f5]">
+        <div className="flex items-center gap-2 flex-1 bg-[#f8fafb] border border-[#e8eef0] rounded-xl px-3.5 py-2.5">
+          <Search size={14} className="text-[#8aa3ad] shrink-0" />
+          <input
+            type="text"
+            value={busqueda}
+            onChange={(e) => { setBusqueda(e.target.value); setPaginaActual(1); }}
+            placeholder="Buscar areas..."
+            className="flex-1 text-sm bg-transparent outline-none text-[#0F1819] placeholder:text-[#c5d5db]"
+          />
+        </div>
+        <button className="flex items-center gap-2 px-3.5 py-2.5 text-sm text-[#203D47] border border-[#d1dde2] rounded-xl hover:bg-[#ECEFF1] transition-colors">
+          <Filter size={14} />
+          Filtrar
+        </button>
+        <button className="flex items-center gap-2 px-3.5 py-2.5 text-sm text-[#203D47] border border-[#d1dde2] rounded-xl hover:bg-[#ECEFF1] transition-colors">
+          <Download size={14} />
+          Exportar
+        </button>
+      </div>
+
+      {/* Tabla */}
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-[#f0f4f5]">
+              <th className="px-5 py-3 text-left text-[10px] font-bold text-[#8aa3ad] uppercase tracking-widest">
+                Nombre del Area
+              </th>
+              <th className="px-5 py-3 text-left text-[10px] font-bold text-[#8aa3ad] uppercase tracking-widest">
+                Descripcion
+              </th>
+              <th className="px-5 py-3 text-left text-[10px] font-bold text-[#8aa3ad] uppercase tracking-widest">
+                Posiciones
+              </th>
+              <th className="px-5 py-3 text-left text-[10px] font-bold text-[#8aa3ad] uppercase tracking-widest">
+                Estado
+              </th>
+              <th className="px-5 py-3 text-left text-[10px] font-bold text-[#8aa3ad] uppercase tracking-widest">
+                Acciones
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {areasPagina.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-5 py-10 text-center text-sm text-[#8aa3ad]">
+                  No se encontraron areas con esa busqueda.
+                </td>
+              </tr>
+            ) : (
+              areasPagina.map((area) => (
+                <AreaRow
+                  key={area.id}
+                  area={area}
+                  onVer={onVer}
+                  onEditar={onEditar}
+                  onEliminar={onEliminar}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Paginacion */}
+      <div className="flex items-center justify-between px-5 py-4 border-t border-[#f0f4f5]">
+        <span className="text-xs text-[#8aa3ad]">
+          Mostrando {areasFiltradas.length === 0 ? 0 : inicio + 1} a{" "}
+          {Math.min(inicio + ITEMS_POR_PAGINA, areasFiltradas.length)} de{" "}
+          {areasFiltradas.length} registros
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => irAPagina(paginaActual - 1)}
+            disabled={paginaActual === 1}
+            className="px-3 py-1.5 text-xs border border-[#d1dde2] rounded-lg text-[#203D47] hover:bg-[#ECEFF1] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Anterior
+          </button>
+          {Array.from({ length: totalPaginas }, (_, i) => i + 1).map((pagina) => (
+            <button
+              key={pagina}
+              onClick={() => irAPagina(pagina)}
+              className={`w-8 h-8 text-xs rounded-lg transition-colors ${
+                pagina === paginaActual
+                  ? "bg-emerald-500 text-white font-semibold"
+                  : "border border-[#d1dde2] text-[#203D47] hover:bg-[#ECEFF1]"
+              }`}
+            >
+              {pagina}
+            </button>
+          ))}
+          <button
+            onClick={() => irAPagina(paginaActual + 1)}
+            disabled={paginaActual === totalPaginas}
+            className="px-3 py-1.5 text-xs border border-[#d1dde2] rounded-lg text-[#203D47] hover:bg-[#ECEFF1] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Siguiente
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/areas/DeleteAreaModal.tsx
+++ b/components/areas/DeleteAreaModal.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React, { useState } from "react";
+import { AlertTriangle, AlertCircle } from "lucide-react";
+import { Area, eliminarArea } from "@/services/areasService";
+
+interface DeleteAreaModalProps {
+  area: Area;
+  onCerrar: () => void;
+  onEliminada: () => void;
+}
+
+export default function DeleteAreaModal({ area, onCerrar, onEliminada }: DeleteAreaModalProps) {
+  const [eliminando, setEliminando] = useState(false);
+  const tieneposiciones = area.posiciones > 0;
+
+  const manejarEliminar = async () => {
+    setEliminando(true);
+    try {
+      await eliminarArea(area.id);
+      onEliminada();
+    } finally {
+      setEliminando(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6 flex flex-col gap-4">
+        {/* Icono y titulo */}
+        <div className="flex items-start gap-3">
+          <div className="w-9 h-9 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+            <AlertTriangle size={18} className="text-amber-500" />
+          </div>
+          <div>
+            <h2 className="text-base font-semibold text-[#0F1819]">Eliminar esta area?</h2>
+            <p className="text-sm text-[#8aa3ad] mt-1 leading-relaxed">
+              Esta seguro que quiere eliminar el{" "}
+              <span className="font-semibold text-[#0F1819]">{area.nombre}</span>?
+              Esta accion no se puede deshacer.
+            </p>
+          </div>
+        </div>
+
+        {/* Advertencia de posiciones enlazadas */}
+        {tieneposiciones && (
+          <div className="flex items-start gap-2.5 bg-rose-50 border border-rose-200 rounded-xl px-4 py-3">
+            <AlertCircle size={15} className="text-rose-500 shrink-0 mt-0.5" />
+            <div>
+              <p className="text-sm font-semibold text-rose-600">
+                Esta area tiene {area.posiciones} posiciones enlazadas.
+              </p>
+              <p className="text-xs text-rose-400 mt-0.5">
+                Todas las posiciones enlazadas deben ser reasignadas o cerradas antes de eliminar esta area.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Botones */}
+        <div className="flex items-center justify-end gap-3 pt-1">
+          <button
+            onClick={onCerrar}
+            className="px-4 py-2 text-sm text-[#8aa3ad] hover:text-[#0F1819] border border-[#d1dde2] rounded-lg transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={manejarEliminar}
+            disabled={eliminando}
+            className="px-4 py-2 text-sm font-semibold text-white bg-rose-500 hover:bg-rose-400 rounded-lg transition-colors disabled:opacity-60"
+          >
+            {eliminando ? "Eliminando..." : "Eliminar Area"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/areas/EditAreaModal.tsx
+++ b/components/areas/EditAreaModal.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React, { useState } from "react";
+import { X, ChevronDown } from "lucide-react";
+import { Area, editarArea } from "@/services/areasService";
+
+interface EditAreaModalProps {
+  area: Area;
+  todasLasAreas: Area[];
+  onCerrar: () => void;
+  onEditada: () => void;
+}
+
+export default function EditAreaModal({ area, todasLasAreas, onCerrar, onEditada }: EditAreaModalProps) {
+  const [nombre, setNombre] = useState(area.nombre);
+  const [descripcion, setDescripcion] = useState(area.descripcion);
+  const [areaPadreId, setAreaPadreId] = useState<string>("");
+  const [activo, setActivo] = useState(area.estado === "ACTIVO");
+  const [guardando, setGuardando] = useState(false);
+  const [errores, setErrores] = useState<{ nombre?: string }>({});
+
+  const validar = () => {
+    const nuevosErrores: typeof errores = {};
+    if (!nombre.trim()) nuevosErrores.nombre = "El nombre del area es obligatorio.";
+    setErrores(nuevosErrores);
+    return Object.keys(nuevosErrores).length === 0;
+  };
+
+  const manejarGuardar = async () => {
+    if (!validar()) return;
+    setGuardando(true);
+    try {
+      await editarArea(area.id, {
+        nombre: nombre.trim(),
+        descripcion: descripcion.trim(),
+        estado: activo ? "ACTIVO" : "INACTIVO",
+      });
+      onEditada();
+    } finally {
+      setGuardando(false);
+    }
+  };
+
+  const areasFiltradas = todasLasAreas.filter((a) => a.id !== area.id);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4">
+        {/* Encabezado */}
+        <div className="flex items-center justify-between px-6 py-5 border-b border-[#f0f4f5]">
+          <h2 className="text-base font-semibold text-[#0F1819]">Editar Area</h2>
+          <button
+            onClick={onCerrar}
+            className="p-1.5 text-[#8aa3ad] hover:text-[#0F1819] hover:bg-[#f4f7f8] rounded-lg transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Campos */}
+        <div className="px-6 py-5 flex flex-col gap-5">
+          {/* Nombre */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-[#0F1819]">
+              Nombre del Area <span className="text-rose-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={nombre}
+              onChange={(e) => { setNombre(e.target.value); setErrores({}); }}
+              className={`w-full px-3.5 py-2.5 text-sm border rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-400 text-[#0F1819] ${
+                errores.nombre ? "border-rose-400 bg-rose-50" : "border-[#d1dde2]"
+              }`}
+            />
+            {errores.nombre && <p className="text-xs text-rose-500">{errores.nombre}</p>}
+          </div>
+
+          {/* Area padre */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-[#0F1819]">Area Padre</label>
+            <div className="relative">
+              <select
+                value={areaPadreId}
+                onChange={(e) => setAreaPadreId(e.target.value)}
+                className="w-full appearance-none px-3.5 py-2.5 text-sm border border-[#d1dde2] rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-400 text-[#0F1819] bg-white pr-10"
+              >
+                <option value="">Sin area padre</option>
+                {areasFiltradas.map((a) => (
+                  <option key={a.id} value={a.id}>{a.nombre}</option>
+                ))}
+              </select>
+              <ChevronDown size={14} className="absolute right-3 top-1/2 -translate-y-1/2 text-[#8aa3ad] pointer-events-none" />
+            </div>
+          </div>
+
+          {/* Descripcion */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-[#0F1819]">Descripcion</label>
+            <textarea
+              value={descripcion}
+              onChange={(e) => setDescripcion(e.target.value)}
+              rows={4}
+              className="w-full px-3.5 py-2.5 text-sm border border-[#d1dde2] rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-400 text-[#0F1819] resize-none"
+            />
+          </div>
+
+          {/* Estado toggle */}
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-[#0F1819]">Estado</label>
+            <p className="text-xs text-[#8aa3ad]">Controla si esta area es visible en la planificacion de talento.</p>
+            <div className="flex items-center gap-3 mt-1">
+              <button
+                onClick={() => setActivo(!activo)}
+                className={`relative w-10 h-6 rounded-full transition-colors ${activo ? "bg-emerald-500" : "bg-[#d1dde2]"}`}
+              >
+                <span
+                  className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${activo ? "translate-x-5" : "translate-x-1"}`}
+                />
+              </button>
+              <span className={`text-sm font-medium ${activo ? "text-emerald-600" : "text-[#8aa3ad]"}`}>
+                {activo ? "Activo" : "Inactivo"}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Botones */}
+        <div className="flex items-center justify-end gap-3 px-6 pb-6">
+          <button
+            onClick={onCerrar}
+            className="px-4 py-2 text-sm text-[#8aa3ad] hover:text-[#0F1819] border border-[#d1dde2] rounded-lg transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={manejarGuardar}
+            disabled={guardando}
+            className="px-4 py-2 text-sm font-semibold text-white bg-emerald-500 hover:bg-emerald-400 rounded-lg transition-colors disabled:opacity-60"
+          >
+            {guardando ? "Guardando..." : "Guardar Cambios"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/areas/EditAreaModal.tsx
+++ b/components/areas/EditAreaModal.tsx
@@ -18,6 +18,8 @@ export default function EditAreaModal({ area, todasLasAreas, onCerrar, onEditada
   const [activo, setActivo] = useState(area.estado === "ACTIVO");
   const [guardando, setGuardando] = useState(false);
   const [errores, setErrores] = useState<{ nombre?: string }>({});
+  const isActive = activo;
+
 
   const validar = () => {
     const nuevosErrores: typeof errores = {};
@@ -68,9 +70,8 @@ export default function EditAreaModal({ area, todasLasAreas, onCerrar, onEditada
               type="text"
               value={nombre}
               onChange={(e) => { setNombre(e.target.value); setErrores({}); }}
-              className={`w-full px-3.5 py-2.5 text-sm border rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-400 text-[#0F1819] ${
-                errores.nombre ? "border-rose-400 bg-rose-50" : "border-[#d1dde2]"
-              }`}
+              className={`w-full px-3.5 py-2.5 text-sm border rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-400 text-[#0F1819] ${errores.nombre ? "border-rose-400 bg-rose-50" : "border-[#d1dde2]"
+                }`}
             />
             {errores.nombre && <p className="text-xs text-rose-500">{errores.nombre}</p>}
           </div>
@@ -108,19 +109,23 @@ export default function EditAreaModal({ area, todasLasAreas, onCerrar, onEditada
           <div className="flex flex-col gap-1">
             <label className="text-sm font-medium text-[#0F1819]">Estado</label>
             <p className="text-xs text-[#8aa3ad]">Controla si esta area es visible en la planificacion de talento.</p>
-            <div className="flex items-center gap-3 mt-1">
-              <button
-                onClick={() => setActivo(!activo)}
-                className={`relative w-10 h-6 rounded-full transition-colors ${activo ? "bg-emerald-500" : "bg-[#d1dde2]"}`}
-              >
-                <span
-                  className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${activo ? "translate-x-5" : "translate-x-1"}`}
-                />
-              </button>
-              <span className={`text-sm font-medium ${activo ? "text-emerald-600" : "text-[#8aa3ad]"}`}>
-                {activo ? "Activo" : "Inactivo"}
-              </span>
-            </div>
+            <button
+              onClick={() => setActivo(!activo)}
+              className={`relative w-10 h-6 rounded-full transition-colors ${activo ? "bg-emerald-500" : "bg-[#d1dde2]"
+                }`}
+            >
+              <span
+                className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${activo ? "translate-x-4" : "translate-x-0"
+                  }`}
+              />
+            </button>
+
+            <span
+              className={`text-sm font-medium ${isActive ? "text-emerald-600" : "text-[#8aa3ad]"
+                }`}
+            >
+              {isActive ? "Activo" : "Inactivo"}
+            </span>
           </div>
         </div>
 

--- a/components/areas/NewAreaModal.tsx
+++ b/components/areas/NewAreaModal.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React, { useState } from "react";
+import { X } from "lucide-react";
+import { crearArea } from "@/services/areasService";
+
+interface NewAreaModalProps {
+  onCerrar: () => void;
+  onCreada: () => void;
+}
+
+export default function NewAreaModal({ onCerrar, onCreada }: NewAreaModalProps) {
+  const [nombre, setNombre] = useState("");
+  const [descripcion, setDescripcion] = useState("");
+  const [guardando, setGuardando] = useState(false);
+  const [errores, setErrores] = useState<{ nombre?: string; descripcion?: string }>({});
+
+  const validar = () => {
+    const nuevosErrores: typeof errores = {};
+    if (!nombre.trim()) nuevosErrores.nombre = "El nombre del area es obligatorio.";
+    if (!descripcion.trim()) nuevosErrores.descripcion = "La descripcion es obligatoria.";
+    setErrores(nuevosErrores);
+    return Object.keys(nuevosErrores).length === 0;
+  };
+
+  const manejarGuardar = async () => {
+    if (!validar()) return;
+    setGuardando(true);
+    try {
+      await crearArea({
+        nombre: nombre.trim(),
+        descripcion: descripcion.trim(),
+        posiciones: 0,
+        estado: "ACTIVO",
+        color: "#10B981",
+        icono: "default",
+      });
+      onCreada();
+    } finally {
+      setGuardando(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4">
+        {/* Encabezado */}
+        <div className="flex items-center justify-between px-6 py-5 border-b border-[#f0f4f5]">
+          <h2 className="text-base font-semibold text-[#0F1819]">Crear Nueva Area</h2>
+          <button
+            onClick={onCerrar}
+            className="p-1.5 text-[#8aa3ad] hover:text-[#0F1819] hover:bg-[#f4f7f8] rounded-lg transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Campos */}
+        <div className="px-6 py-5 flex flex-col gap-5">
+          {/* Nombre */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-[#0F1819]">
+              Nombre del Area <span className="text-rose-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={nombre}
+              onChange={(e) => { setNombre(e.target.value); setErrores((p) => ({ ...p, nombre: undefined })); }}
+              placeholder="ej. Marketing de Producto"
+              className={`w-full px-3.5 py-2.5 text-sm border rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-400 text-[#0F1819] placeholder:text-[#c5d5db] ${
+                errores.nombre ? "border-rose-400 bg-rose-50" : "border-[#d1dde2]"
+              }`}
+            />
+            {errores.nombre && <p className="text-xs text-rose-500">{errores.nombre}</p>}
+          </div>
+
+          {/* Descripcion */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-[#0F1819]">Descripcion</label>
+            <textarea
+              value={descripcion}
+              onChange={(e) => { setDescripcion(e.target.value); setErrores((p) => ({ ...p, descripcion: undefined })); }}
+              placeholder="Proporciona una breve descripcion de las responsabilidades y proposito del area..."
+              rows={4}
+              maxLength={500}
+              className={`w-full px-3.5 py-2.5 text-sm border rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-400 text-[#0F1819] placeholder:text-[#c5d5db] resize-none ${
+                errores.descripcion ? "border-rose-400 bg-rose-50" : "border-[#d1dde2]"
+              }`}
+            />
+            <p className="text-xs text-[#8aa3ad] text-right">{descripcion.length}/500 caracteres.</p>
+            {errores.descripcion && <p className="text-xs text-rose-500">{errores.descripcion}</p>}
+          </div>
+        </div>
+
+        {/* Botones */}
+        <div className="flex items-center justify-end gap-3 px-6 pb-6">
+          <button
+            onClick={onCerrar}
+            className="px-4 py-2 text-sm text-[#8aa3ad] hover:text-[#0F1819] border border-[#d1dde2] rounded-lg transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={manejarGuardar}
+            disabled={guardando}
+            className="px-4 py-2 text-sm font-semibold text-white bg-[#0F1819] hover:bg-[#1E333A] rounded-lg transition-colors disabled:opacity-60"
+          >
+            {guardando ? "Guardando..." : "Guardar Area"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/areas/Toast.tsx
+++ b/components/areas/Toast.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { CheckCircle, XCircle, X } from "lucide-react";
+
+interface ToastProps {
+  mensaje: string;
+  tipo: "exito" | "error";
+  onCerrar: () => void;
+}
+
+export default function Toast({ mensaje, tipo, onCerrar }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(onCerrar, 3500);
+    return () => clearTimeout(timer);
+  }, [onCerrar]);
+
+  return (
+    <div
+      className={`fixed top-6 right-6 z-50 flex items-center gap-3 px-4 py-3 rounded-xl shadow-lg text-white text-sm font-medium
+        ${tipo === "exito" ? "bg-emerald-500" : "bg-rose-500"}`}
+      style={{ animation: "fadeDown 0.25s ease-out" }}
+    >
+      <style>{`
+        @keyframes fadeDown {
+          from { opacity: 0; transform: translateY(-12px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+      {tipo === "exito"
+        ? <CheckCircle size={16} className="shrink-0" />
+        : <XCircle size={16} className="shrink-0" />
+      }
+      <span>{mensaje}</span>
+      <button onClick={onCerrar} className="ml-2 hover:opacity-75 transition-opacity">
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/components/areas/ViewAreaModal.tsx
+++ b/components/areas/ViewAreaModal.tsx
@@ -1,0 +1,90 @@
+"use client";
+import React from "react";
+import { X, FolderKanban, Users, Briefcase, Activity } from "lucide-react";
+import { Area } from "@/services/areasService";
+
+interface ViewAreaModalProps {
+  area: Area;
+  onCerrar: () => void;
+}
+
+const BADGE_ESTADO: Record<string, string> = {
+  ACTIVO:      "bg-emerald-100 text-emerald-700",
+  INACTIVO:    "bg-slate-100 text-slate-500",
+  EN_REVISION: "bg-amber-100 text-amber-700",
+};
+
+const ETIQUETA_ESTADO: Record<string, string> = {
+  ACTIVO:      "Activo",
+  INACTIVO:    "Inactivo",
+  EN_REVISION: "En revision",
+};
+
+function FilaDetalle({ icono: Icono, etiqueta, valor }: { icono: any; etiqueta: string; valor: string | number }) {
+  return (
+    <div className="flex items-center gap-3 py-3 border-b border-[#f0f4f5] last:border-0">
+      <div className="w-8 h-8 rounded-lg bg-[#f4f7f8] flex items-center justify-center shrink-0">
+        <Icono size={15} className="text-[#203D47]" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-[10px] uppercase tracking-widest text-[#8aa3ad] font-semibold">{etiqueta}</p>
+        <p className="text-sm font-medium text-[#0F1819] mt-0.5">{valor}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function ViewAreaModal({ area, onCerrar }: ViewAreaModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4">
+        {/* Encabezado */}
+        <div className="flex items-center justify-between px-6 py-5 border-b border-[#f0f4f5]">
+          <div className="flex items-center gap-3">
+            <div
+              className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
+              style={{ backgroundColor: area.color + "22" }}
+            >
+              <FolderKanban size={16} style={{ color: area.color }} />
+            </div>
+            <div>
+              <h2 className="text-base font-semibold text-[#0F1819]">{area.nombre}</h2>
+              <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${BADGE_ESTADO[area.estado]}`}>
+                {ETIQUETA_ESTADO[area.estado]}
+              </span>
+            </div>
+          </div>
+          <button
+            onClick={onCerrar}
+            className="p-1.5 text-[#8aa3ad] hover:text-[#0F1819] hover:bg-[#f4f7f8] rounded-lg transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Descripcion */}
+        <div className="px-6 pt-5 pb-2">
+          <p className="text-[10px] uppercase tracking-widest text-[#8aa3ad] font-semibold mb-1">Descripcion</p>
+          <p className="text-sm text-[#203D47] leading-relaxed">{area.descripcion}</p>
+        </div>
+
+        {/* Detalles */}
+        <div className="px-6 py-2">
+          <FilaDetalle icono={Users} etiqueta="Posiciones" valor={area.posiciones} />
+          <FilaDetalle icono={Briefcase} etiqueta="Estado" valor={ETIQUETA_ESTADO[area.estado]} />
+          <FilaDetalle icono={Activity} etiqueta="Identificador de color" valor={area.color.toUpperCase()} />
+        </div>
+
+        {/* Boton cerrar */}
+        <div className="flex justify-end px-6 pb-6 pt-2">
+          <button
+            onClick={onCerrar}
+            className="px-4 py-2 text-sm text-[#8aa3ad] hover:text-[#0F1819] border border-[#d1dde2] rounded-lg transition-colors"
+          >
+            Cerrar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/services/areasService.ts
+++ b/services/areasService.ts
@@ -1,0 +1,94 @@
+// Backend simulado — se reemplazzara por fetch real a Supabase cuando este disponible
+
+export interface Area {
+  id: string;
+  nombre: string;
+  descripcion: string;
+  posiciones: number;
+  estado: "ACTIVO" | "INACTIVO" | "EN_REVISION";
+  color: string;
+  icono: string;
+}
+
+const AREAS_MOCK: Area[] = [
+  {
+    id: "1",
+    nombre: "Departamento de Ingenieria",
+    descripcion: "Desarrollo de software, QA y DevOps...",
+    posiciones: 42,
+    estado: "ACTIVO",
+    color: "#3B82F6",
+    icono: "ingenieria",
+  },
+  {
+    id: "2",
+    nombre: "Cumplimiento Corporativo",
+    descripcion: "Estandares regulatorios y politicas internas...",
+    posiciones: 12,
+    estado: "ACTIVO",
+    color: "#8B5CF6",
+    icono: "cumplimiento",
+  },
+  {
+    id: "3",
+    nombre: "Operaciones Financieras",
+    descripcion: "Contabilidad, nomina y gestion presupuestaria...",
+    posiciones: 28,
+    estado: "ACTIVO",
+    color: "#F59E0B",
+    icono: "finanzas",
+  },
+  {
+    id: "4",
+    nombre: "Marketing y Comunicaciones",
+    descripcion: "Estrategia de marca, PR y marketing digital...",
+    posiciones: 18,
+    estado: "ACTIVO",
+    color: "#EC4899",
+    icono: "marketing",
+  },
+  {
+    id: "5",
+    nombre: "Exito del Cliente",
+    descripcion: "Soporte al cliente y gestion de cuentas...",
+    posiciones: 35,
+    estado: "ACTIVO",
+    color: "#10B981",
+    icono: "clientes",
+  },
+  {
+    id: "6",
+    nombre: "Recursos Humanos",
+    descripcion: "Adquisicion de talento, cultura y beneficios...",
+    posiciones: 15,
+    estado: "ACTIVO",
+    color: "#F97316",
+    icono: "rrhh",
+  },
+];
+
+export const obtenerAreas = async (): Promise<Area[]> => {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  return AREAS_MOCK;
+};
+
+export const crearArea = async (datos: Omit<Area, "id">): Promise<Area> => {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const nueva: Area = { ...datos, id: Date.now().toString() };
+  AREAS_MOCK.push(nueva);
+  return nueva;
+};
+
+export const editarArea = async (id: string, datos: Partial<Area>): Promise<Area> => {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const index = AREAS_MOCK.findIndex((a) => a.id === id);
+  if (index === -1) throw new Error("Area no encontrada");
+  AREAS_MOCK[index] = { ...AREAS_MOCK[index], ...datos };
+  return AREAS_MOCK[index];
+};
+
+export const eliminarArea = async (id: string): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const index = AREAS_MOCK.findIndex((a) => a.id === id);
+  if (index !== -1) AREAS_MOCK.splice(index, 1);
+};


### PR DESCRIPTION
¿Qué hace este PR?
- Implementa la página de gestión de áreas en /dashboard/areas
- Tabla con búsqueda, filtro, exportar y paginación
- Modal para crear nueva área (nombre y descripción)
- Modal para editar área (nombre, área padre, descripción y toggle de estado)
- Modal de confirmación para eliminar con advertencia de posiciones enlazadas
- Modal de ver detalles del área
- Notificaciones toast en la esquina superior derecha
- Datos simulados con mock — listos para conectar a Supabase

Archivos creados
- app/dashboard/areas/page.tsx
- components/areas/AreasTable.tsx
- components/areas/AreaRow.tsx
- components/areas/NewAreaModal.tsx
- components/areas/EditAreaModal.tsx
- components/areas/DeleteAreaModal.tsx
- components/areas/ViewAreaModal.tsx
- components/areas/Toast.tsx
- services/areasService.ts