### PR TITLE
[feat] implementar admin dashboard con stats, alertas y jerarquia

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,107 @@
+// app/dashboard/page.tsx
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Users, PauseCircle, PersonStanding } from "lucide-react";
+
+import Header from "@/components/Header";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import StatsCard from "@/components/dashboard/StatsCard";
+import CriticalContractAlerts from "@/components/dashboard/CriticalContractAlerts";
+import DepartmentalHierarchy from "@/components/dashboard/DepartmentalHierarchy";
+
+import {
+  obtenerEstadisticas,
+  obtenerAlertasContratos,
+  obtenerJerarquiaDepartamental,
+  EstadisticaDashboard,
+  AlertaContrato,
+} from "@/services/dashboardService";
+
+import { NodoOrg } from "@/types/orgChart";
+
+export default function DashboardPage() {
+  const [estadisticas, setEstadisticas] = useState<EstadisticaDashboard | null>(null);
+  const [alertas, setAlertas] = useState<AlertaContrato[]>([]);
+  const [departamentos, setDepartamentos] = useState<NodoOrg[]>([]);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    Promise.all([
+      obtenerEstadisticas(),
+      obtenerAlertasContratos(),
+      obtenerJerarquiaDepartamental(),
+    ])
+      .then(([stats, alertasData, depsData]) => {
+        setEstadisticas(stats);
+        setAlertas(alertasData);
+        setDepartamentos(depsData);
+      })
+      .catch(() => setError("No se pudieron cargar los datos del dashboard."))
+      .finally(() => setCargando(false));
+  }, []);
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#f4f7f8]">
+      {/* Header común reutilizable */}
+      <Header user={null} />
+
+      {/* Contenido principal */}
+      <main className="flex-1 px-6 py-6 overflow-auto">
+        {/* Título */}
+        <div className="mb-6">
+          <h1 className="text-xl font-bold text-[#0F1819]">Pulso Organizacional</h1>
+          <p className="text-sm text-[#8aa3ad] mt-0.5">
+            Supervision en tiempo real del capital humano y contratos estrategicos.
+          </p>
+        </div>
+
+        {cargando && <LoadingSpinner mensaje="Cargando panel principal..." />}
+
+        {error && (
+          <div className="bg-white rounded-xl px-6 py-4 border border-rose-200 text-sm text-rose-500">
+            {error}
+          </div>
+        )}
+
+        {!cargando && !error && estadisticas && (
+          <>
+            {/* Tarjetas de estadísticas */}
+            <div className="flex gap-4 mb-6">
+              <StatsCard
+                icono={Users}
+                etiqueta="Personal Activo"
+                valor={estadisticas.personalActivo}
+                variacion={estadisticas.variacionPersonalActivo}
+              />
+              <StatsCard
+                icono={PauseCircle}
+                etiqueta="Suspendidos"
+                valor={estadisticas.suspendidos}
+                etiquetaVariacion={estadisticas.estadoSuspendidos}
+              />
+              <StatsCard
+                icono={PersonStanding}
+                etiqueta="Retirados (año actual)"
+                valor={estadisticas.retiradosYTD}
+                variacion={estadisticas.variacionRetirados}
+              />
+            </div>
+
+            {/* Secciones inferiores */}
+            <div className="grid grid-cols-2 gap-4">
+              <CriticalContractAlerts alertas={alertas} />
+              <DepartmentalHierarchy departamentos={departamentos} />
+            </div>
+          </>
+        )}
+      </main>
+
+      {/* Botón flotante */}
+      <button className="fixed bottom-6 right-6 bg-emerald-500 hover:bg-emerald-400 text-white text-sm font-bold px-6 py-3.5 rounded-2xl shadow-lg transition-colors z-50">
+        Evaluaciones
+      </button>
+    </div>
+  );
+}

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+interface LoadingSpinnerProps {
+  mensaje?: string;
+}
+
+export default function LoadingSpinner({ mensaje = "Cargando..." }: LoadingSpinnerProps) {
+  return (
+    <div className="flex items-center justify-center py-20">
+      <div className="flex flex-col items-center gap-3">
+        <div className="w-8 h-8 rounded-full border-2 border-[#203D47] border-t-emerald-400 animate-spin" />
+        <span className="text-xs text-[#8aa3ad]">{mensaje}</span>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/CriticalContractAlerts.tsx
+++ b/components/dashboard/CriticalContractAlerts.tsx
@@ -1,0 +1,67 @@
+// components/dashboard/CriticalContractAlerts.tsx
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { AlertaContrato } from "@/services/dashboardService";
+
+interface Props {
+  alertas: AlertaContrato[];
+}
+
+function colorPorDias(dias: number): string {
+  if (dias <= 7) return "text-rose-500";
+  if (dias <= 14) return "text-orange-500";
+  return "text-blue-500";
+}
+
+export default function CriticalContractAlerts({ alertas }: Props) {
+  return (
+    <div className="bg-white rounded-2xl p-5 border border-[#e4ebee] flex flex-col h-full">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <AlertTriangle size={16} className="text-amber-500" />
+          <h2 className="text-sm font-bold text-[#0F1819]">Alertas Críticas de Contratos</h2>
+        </div>
+        <span className="text-xs text-[#8aa3ad] font-medium">Próximos 30 días</span>
+      </div>
+
+      <div className="flex flex-col gap-3 flex-1">
+        {alertas.map((alerta) => {
+          const color = colorPorDias(alerta.diasRestantes);
+          return (
+            <div
+              key={alerta.idContrato} 
+              className="flex items-center justify-between py-2 border-b border-[#f0f4f5] last:border-0"
+            >
+              <div className="flex items-center gap-3">
+                <div className="w-8 h-8 rounded-xl bg-[#ECEFF1] flex items-center justify-center shrink-0">
+                  <span className="text-xs font-bold text-[#203D47]">
+                    {alerta.nombre.charAt(0)}
+                  </span>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-[#0F1819] leading-none">
+                    {alerta.nombre}
+                  </p>
+                  <p className="text-xs text-[#8aa3ad] mt-0.5">
+                    ID: {alerta.codigoContrato} • {alerta.departamento}
+                  </p>
+                </div>
+              </div>
+              <div className="text-right shrink-0 ml-4">
+                <p className={`text-xs font-bold ${color}`}>
+                  Exp. en {alerta.diasRestantes} días
+                </p>
+                <p className="text-xs text-[#8aa3ad]">{alerta.fechaFin}</p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <button className="mt-4 text-xs text-[#8aa3ad] hover:text-[#203D47] transition-colors font-medium text-center w-full pt-3 border-t border-[#f0f4f5]">
+        Ver todos los hitos contractuales
+      </button>
+    </div>
+  );
+}

--- a/components/dashboard/DepartmentalHierarchy.tsx
+++ b/components/dashboard/DepartmentalHierarchy.tsx
@@ -1,0 +1,58 @@
+// components/dashboard/DepartmentalHierarchy.tsx
+"use client";
+
+import { GitFork } from "lucide-react";
+import { NodoOrg } from "@/types/orgChart";
+
+interface Props {
+  departamentos: NodoOrg[];
+}
+
+const COLORES_NIVEL: Record<string, string> = {
+  EJECUTIVO:       "bg-[#203D47] text-white",
+  TECNICO:         "bg-[#BDD5EA] text-[#203D47]",
+  INFRAESTRUCTURA: "bg-[#BDD5EA] text-[#203D47]",
+  SEGURIDAD:       "bg-[#ECEFF1] text-[#203D47]",
+  GESTION:         "bg-[#ECEFF1] text-[#203D47]",
+  OPERACIONES:     "bg-[#ECEFF1] text-[#203D47]",
+};
+
+export default function DepartmentalHierarchy({ departamentos }: Props) {
+  return (
+    <div className="bg-white rounded-2xl p-5 border border-[#e4ebee] flex flex-col h-full">
+      <div className="flex items-center gap-2 mb-4">
+        <GitFork size={16} className="text-[#203D47]" />
+        <h2 className="text-sm font-bold text-[#0F1819]">Jerarquía Departamental</h2>
+      </div>
+
+      <div className="flex flex-col gap-4 flex-1">
+        {departamentos.map((dep) => {
+          const badgeClase = COLORES_NIVEL[dep.nivel] ?? "bg-[#ECEFF1] text-[#203D47]";
+
+          return (
+            <div key={dep.id} className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="text-[10px] font-semibold tracking-wide text-[#8aa3ad] capitalize">
+                    {dep.nivel}
+                  </span>
+                  <p className="text-sm font-bold text-[#0F1819] leading-tight">{dep.nombre}</p>
+                </div>
+                <span className={`text-xs font-semibold px-2.5 py-1 rounded-lg shrink-0 ${badgeClase}`}>
+                  {dep.cantidadMiembros} Empleados
+                </span>
+              </div>
+              {/* Barra de progreso — usa utilizacionPresupuesto que ya es 0-100 */}
+              <div className="h-1.5 bg-[#ECEFF1] rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-emerald-500 rounded-full transition-all duration-700"
+                  style={{ width: `${dep.utilizacionPresupuesto}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/StatsCard.tsx
+++ b/components/dashboard/StatsCard.tsx
@@ -1,0 +1,46 @@
+// components/dashboard/StatsCard.tsx
+"use client";
+
+import { LucideIcon } from "lucide-react";
+
+interface StatsCardProps {
+  icono: LucideIcon;
+  etiqueta: string;
+  valor: number | string;
+  variacion?: number;
+  etiquetaVariacion?: string;
+  colorIcono?: string;
+}
+
+export default function StatsCard({
+  icono: Icono,
+  etiqueta,
+  valor,
+  variacion,
+  etiquetaVariacion,
+  colorIcono = "text-emerald-500",
+}: StatsCardProps) {
+  const esPositivo = variacion !== undefined && variacion >= 0;
+  const colorVariacion = esPositivo ? "text-emerald-500" : "text-rose-500";
+
+  return (
+    <div className="bg-white rounded-2xl p-5 flex-1 min-w-0 border border-[#e4ebee]">
+      <div className="flex items-start justify-between mb-4">
+        <div className={`p-2 rounded-xl bg-[#ECEFF1] ${colorIcono}`}>
+          <Icono size={18} />
+        </div>
+        {variacion !== undefined && (
+          <span className={`text-xs font-semibold ${colorVariacion}`}>
+            {esPositivo ? "+" : ""}
+            {variacion}%
+          </span>
+        )}
+        {etiquetaVariacion && !variacion && (
+          <span className="text-xs font-medium text-[#8aa3ad]">{etiquetaVariacion}</span>
+        )}
+      </div>
+      <p className="text-sm text-[#8aa3ad] mb-1">{etiqueta}</p>
+      <p className="text-3xl font-bold text-[#0F1819]">{valor.toLocaleString()}</p>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.3",
-        "lucide-react": "^1.7.0",
+        "lucide-react": "^1.8.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -5000,9 +5000,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
-      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.3",
-    "lucide-react": "^1.7.0",
+    "lucide-react": "^1.8.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/services/dashboardService.ts
+++ b/services/dashboardService.ts
@@ -1,0 +1,121 @@
+// services/dashboardService.ts
+import { ContratoBase } from "@/types/contrato";
+import { NodoOrg } from "@/types/orgChart";
+
+export interface EstadisticaDashboard {
+  personalActivo: number;
+  variacionPersonalActivo: number;
+  suspendidos: number;
+  estadoSuspendidos: "Stable" | "Up" | "Down";
+  retiradosYTD: number;
+  variacionRetirados: number;
+}
+
+export interface AlertaContrato extends ContratoBase {
+  nombre: string;
+  codigoContrato: string;
+  departamento: string; // string simple, no AreaBase, para consistencia con el componente
+  diasRestantes: number;
+}
+
+export async function obtenerEstadisticas(): Promise<EstadisticaDashboard> {
+  await new Promise((r) => setTimeout(r, 400));
+  return {
+    personalActivo: 1248,
+    variacionPersonalActivo: 2.4,
+    suspendidos: 12,
+    estadoSuspendidos: "Stable",
+    retiradosYTD: 45,
+    variacionRetirados: -1.2,
+  };
+}
+
+export async function obtenerAlertasContratos(): Promise<AlertaContrato[]> {
+  await new Promise((r) => setTimeout(r, 500));
+  return [
+    {
+      idContrato: 1,
+      nombre: "Líder de Auditoría Externa",
+      codigoContrato: "CN-8829",
+      departamento: "Departamento Financiero",
+      diasRestantes: 4,
+      condiciones: "Contrato externo",
+      tipo: "Externo",
+      vigencia: "vigente",
+      fechaInicio: "2023-01-01",
+      fechaFin: "Oct 24, 2023",
+    },
+    {
+      idContrato: 2,
+      nombre: "Director de Seguridad",
+      codigoContrato: "CN-1102",
+      departamento: "Operaciones",
+      diasRestantes: 12,
+      condiciones: "Contrato de seguridad",
+      tipo: "Interno",
+      vigencia: "vigente",
+      fechaInicio: "2023-01-01",
+      fechaFin: "Nov 02, 2023",
+    },
+    {
+      idContrato: 3,
+      nombre: "Arquitecto de Infraestructura",
+      codigoContrato: "CN-5541",
+      departamento: "Departamento de Ingeniería",
+      diasRestantes: 21,
+      condiciones: "Contrato de infraestructura",
+      tipo: "Interno",
+      vigencia: "vigente",
+      fechaInicio: "2023-01-01",
+      fechaFin: "Nov 11, 2023",
+    },
+  ];
+}
+
+export async function obtenerJerarquiaDepartamental(): Promise<NodoOrg[]> {
+  await new Promise((r) => setTimeout(r, 450));
+  return [
+    {
+      id: "1",
+      nombre: "Junta de Operaciones",
+      nivel: "EJECUTIVO",
+      estado: "ACTIVO",
+      cantidadMiembros: 6,
+      idPadre: null,
+      descripcion: "Nivel ejecutivo principal",
+      avatares: [],
+      vacantes: 1,
+      utilizacionPresupuesto: 60,
+      retencion: 95,
+      lideres: [],
+    },
+    {
+      id: "2",
+      nombre: "Departamento de Ingeniería",
+      nivel: "TECNICO",
+      estado: "ACTIVO",
+      cantidadMiembros: 142,
+      idPadre: "1",
+      descripcion: "Departamento técnico",
+      avatares: [],
+      vacantes: 5,
+      utilizacionPresupuesto: 89,
+      retencion: 88,
+      lideres: [],
+    },
+    {
+      id: "3",
+      nombre: "Cumplimiento Corporativo",
+      nivel: "GESTION",
+      estado: "ESTABLE",
+      cantidadMiembros: 84,
+      idPadre: "1",
+      descripcion: "Cumplimiento corporativo",
+      avatares: [],
+      vacantes: 2,
+      utilizacionPresupuesto: 70,
+      retencion: 91,
+      lideres: [],
+    },
+  ];
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el panel principal del Admin Dashboard (Pulso Organizacional) con visualización de estadísticas de personal, alertas críticas de contratos y jerarquía departamental.

## Archivos creados
- `app/dashboard/page.tsx` — página principal del dashboard
- `components/dashboard/StatsCard.tsx` — tarjeta de estadísticas reutilizable
- `components/dashboard/CriticalContractAlerts.tsx` — sección de alertas de contratos próximos a vencer
- `components/dashboard/DepartmentalHierarchy.tsx` — sección de jerarquía departamental
- `components/LoadingSpinner.tsx` — componente de carga reutilizable (extraído para uso global)
- `services/dashboardService.ts` — funciones para obtener datos del dashboard (datos simulados, pendiente conexión con Supabase)

## Decisiones técnicas
- Se reutiliza `Sidebar` desde `dashboard/layout.tsx` sin modificarlo
- Se reutiliza `Header` existente sin modificarlo
- Los tipos se importan desde `@/types/orgChart` y `@/types/contrato` sin duplicarlos
- Los datos están simulados con `setTimeout` respetando la arquitectura de servicios del proyecto

