### PR TITLE
[feat] crear interfaz de recuperacion de cuenta

### DIFF
--- a/app/recuperar-acceso/page.tsx
+++ b/app/recuperar-acceso/page.tsx
@@ -1,0 +1,30 @@
+// app/recuperar-acceso/page.tsx
+import RecoveryForm from "@/components/RecoveryForm";
+
+export default function RecuperarAcceso() {
+  return (
+    <div className="min-h-screen grid grid-cols-1 md:grid-cols-2">
+
+      {/* Panel izquierdo*/}
+      <div className="bg-[#0f2235] text-white flex flex-col justify-between p-10">
+        <div className="flex items-center gap-2 font-semibold">
+          <p>Portal de Talento Humano</p>
+        </div>
+
+        <div>
+          <h1 className="text-2xl font-bold mb-2">
+            Recupera el acceso a tu cuenta de forma segura
+          </h1>
+          <p className="text-sm text-gray-400">
+            Te enviaremos un enlace para restablecer tus credenciales y restaurar el acceso al portal.
+          </p>
+        </div>
+      </div>
+
+      {/* Panel derecho*/}
+      <div className="bg-gray-100 flex items-center justify-center">
+        <RecoveryForm />
+      </div>
+    </div>
+  );
+}

--- a/components/RecoveryForm.tsx
+++ b/components/RecoveryForm.tsx
@@ -1,0 +1,78 @@
+// components/RecoveryForm.tsx
+"use client";
+
+import { useState } from "react";
+import InputField from "@/components/InputField";
+import AuthButton from "@/components/auth/AuthButton";
+import { enviarEnlaceRecuperacion } from "@/services/recovery";
+import Link from "next/link";
+
+export default function RecoveryForm() {
+  const [correo, setCorreo] = useState("");
+  const [enviado, setEnviado] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cargando, setCargando] = useState(false);
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setCargando(true);
+
+    try {
+      await enviarEnlaceRecuperacion({ correo });
+      setEnviado(true);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Ocurrió un error. Intenta nuevamente.");
+      }
+    } finally {
+      setCargando(false);
+    }
+  };
+
+  return (
+    <div className="bg-white p-8 rounded-xl shadow w-87.5 flex flex-col gap-4">
+      {/* Volver al login */}
+      <Link
+        href="/login"
+        className="text-xs text-gray-500 hover:text-gray-700 transition-colors flex items-center gap-1 w-fit"
+      >
+        ← Volver al login
+      </Link>
+
+      <div>
+        <h2 className="text-lg font-semibold text-center text-gray-700">
+          Recuperar cuenta
+        </h2>
+        <p className="text-xs text-gray-500 text-center mt-1">
+          Ingresa tu correo registrado para recibir las instrucciones de recuperación.
+        </p>
+      </div>
+
+      {/* Mensaje de éxito */}
+      {enviado ? (
+        <div className="bg-green-50 border border-green-200 rounded-lg px-4 py-3 text-sm text-green-700 text-center">
+          ¡Enlace enviado! Revisa tu correo electrónico.
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <InputField
+            label="Correo electrónico"
+            placeholder="nombre@mail.com"
+            value={correo}
+            onChange={(e) => setCorreo(e.target.value)}
+          />
+
+          {/* Mensaje de error */}
+          {error && (
+            <p className="text-xs text-red-500 text-center">{error}</p>
+          )}
+
+          <AuthButton text={cargando ? "Enviando..." : "Enviar enlace de recuperación"} />
+        </form>
+      )}
+    </div>
+  );
+}

--- a/services/recovery.ts
+++ b/services/recovery.ts
@@ -1,0 +1,15 @@
+// services/recovery.ts
+
+export interface RecoveryDTO {
+  correo: string;
+}
+
+export async function enviarEnlaceRecuperacion(data: RecoveryDTO): Promise<void> {
+  // Simulación — reemplazar con llamada real a Supabase
+  await new Promise((r) => setTimeout(r, 800));
+
+  // Simular error si el correo no existe
+  if (!data.correo.includes("@")) {
+    throw new Error("Correo inválido.");
+  }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la pantalla de recuperación de cuenta con layout consistente al login existente.

## Archivos creados
- `app/recuperar-acceso/page.tsx` — página de recuperación de cuenta
- `components/RecoveryForm.tsx` — formulario de recuperación reutilizable
- `services/recovery.ts` — lógica de envío de enlace de recuperación (datos simulados, pendiente conexión con Supabase)

## Decisiones técnicas
- Se reutilizan `InputField` y `AuthButton` existentes sin modificarlos
- Mismo layout de dos paneles que el login (`bg-[#0f2235]` izquierdo, `bg-gray-100` derecho)
- La lógica va en `services/recovery.ts` separada del componente
- Manejo de estado: éxito (mensaje de confirmación) y error (mensaje visible en formulario)

