### PR TITLE
Feat: Implementar modal de confirmación para eliminar posición

### DIFF
--- a/app/dashboard/areas/positions/page.tsx
+++ b/app/dashboard/areas/positions/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import DeletePositionModal from "@/components/areas/positions/DeletePositionModal";
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
   ChevronRight,
@@ -303,6 +303,8 @@ export default function PositionsPage() {
   const [modalLoading, setModalLoading] = useState(false);
   const [toast, setToast] = useState<ToastMessage | null>(null);
   const menuRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [posicionAEliminar, setPosicionAEliminar] = useState<Position | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
 
   // Fetch positions
   const fetchPositions = useCallback(async () => {
@@ -373,29 +375,27 @@ export default function PositionsPage() {
     }
   };
 
-  const handleDeletePosition = async (id: string) => {
-    if (!window.confirm("¿Estás seguro de que deseas eliminar esta posición?"))
-      return;
+ //Nuevo handler para eliminar posición
 
-    try {
-      setLoading(true);
-      await eliminarPosicion(id);
-      setOpenMenuId(null);
-      setToast({
-        title: "Éxito",
-        subtitle: "Posición eliminada correctamente",
-        type: "success",
-      });
-      await fetchPositions();
-    } catch (error) {
-      console.error("Error deleting position:", error);
-      setToast({
-        title: "Error",
-        subtitle: "No se pudo eliminar la posición",
-        type: "error",
-      });
-    }
-  };
+const handleAbrirEliminar = (position: Position) => {
+  setOpenMenuId(null);
+  setPosicionAEliminar(position);
+};
+
+const handleConfirmarEliminar = async (position: Position) => {
+  try {
+    setDeleteLoading(true);
+    await eliminarPosicion(position.id);
+    setPosicionAEliminar(null);
+    setToast({ title: "Éxito", subtitle: "Posición eliminada correctamente", type: "success" });
+    await fetchPositions();
+  } catch (error) {
+    console.error("Error deleting position:", error);
+    setToast({ title: "Error", subtitle: "No se pudo eliminar la posición", type: "error" });
+  } finally {
+    setDeleteLoading(false);
+  }
+};
 
   return (
     <div className="min-h-screen bg-[#ECEFF1]">
@@ -534,6 +534,7 @@ export default function PositionsPage() {
 
                     {openMenuId === position.id && (
                       <div
+                      data-menu-trigger
                         ref={(el) => {
                           if (el) menuRefs.current[position.id] = el;
                         }}
@@ -544,7 +545,7 @@ export default function PositionsPage() {
                           Editar
                         </button>
                         <button
-                          onClick={() => handleDeletePosition(position.id)}
+                          onClick={() => handleAbrirEliminar(position)}
                           className="w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2 transition-colors"
                         >
                           <Trash2 className="w-4 h-4" />
@@ -613,6 +614,16 @@ export default function PositionsPage() {
         onSave={handleNewPosition}
         isLoading={modalLoading}
       />
+      {/*Nuevo modal de eliminación de posiciones*/}
+      <DeletePositionModal
+  isOpen={posicionAEliminar !== null}
+  position={posicionAEliminar}
+  onCerrar={() => setPosicionAEliminar(null)}
+  onEliminada={async () => {
+    setPosicionAEliminar(null);
+    await fetchPositions();
+  }}
+/>
     </div>
   );
 }

--- a/components/areas/positions/DeletePositionModal.tsx
+++ b/components/areas/positions/DeletePositionModal.tsx
@@ -1,38 +1,34 @@
+// components/areas/positions/DeletePositionModal.tsx
 "use client";
 
 import React, { useState } from "react";
 import { AlertTriangle, AlertCircle } from "lucide-react";
-import { eliminarPosicion } from "@/services/positionsService";
+import { Position, eliminarPosicion } from "@/services/positionsService";
 
 interface DeletePositionModalProps {
+  position: Position | null;
   isOpen: boolean;
-  positionId: string | null;
-  positionName: string | null;
-  onClose: () => void;
-  onSuccess?: () => void;
+  onCerrar: () => void;
+  onEliminada: () => void;
 }
 
 export default function DeletePositionModal({
+  position,
   isOpen,
-  positionId,
-  positionName,
-  onClose,
-  onSuccess,
+  onCerrar,
+  onEliminada,
 }: DeletePositionModalProps) {
   const [eliminando, setEliminando] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  if (!isOpen || !positionId) return null;
+  if (!isOpen || !position) return null;
+
+  const tieneEmpleados = position.empleados.length > 0;
 
   const manejarEliminar = async () => {
     setEliminando(true);
-    setError(null);
     try {
-      await eliminarPosicion(positionId);
-      onSuccess?.();
-      onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Error al eliminar la posición");
+      await eliminarPosicion(position.id);
+      onEliminada();
     } finally {
       setEliminando(false);
     }
@@ -41,35 +37,44 @@ export default function DeletePositionModal({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
       <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6 flex flex-col gap-4">
-        {/* Icono y titulo */}
+
+        {/* Icono y título */}
         <div className="flex items-start gap-3">
           <div className="w-9 h-9 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
             <AlertTriangle size={18} className="text-amber-500" />
           </div>
           <div>
-            <h2 className="text-base font-semibold text-[#0F1819]">Eliminar esta posición?</h2>
+            <h2 className="text-base font-semibold text-[#0F1819]">
+              Eliminar esta posición?
+            </h2>
             <p className="text-sm text-[#8aa3ad] mt-1 leading-relaxed">
-              Esta seguro que quiere eliminar la posición{" "}
-              <span className="font-semibold text-[#0F1819]">{positionName}</span>?
-              Esta accion no se puede deshacer.
+              Esta seguro que quiere eliminar la posición de{" "}
+              <span className="font-semibold text-[#0F1819]">{position.nombre}</span>?
+              Esta acción no se puede deshacer.
             </p>
           </div>
         </div>
 
         {/* Advertencia de empleados enlazados */}
-        {error && (
+        {tieneEmpleados && (
           <div className="flex items-start gap-2.5 bg-rose-50 border border-rose-200 rounded-xl px-4 py-3">
             <AlertCircle size={15} className="text-rose-500 shrink-0 mt-0.5" />
-            <p className="text-sm text-rose-600">{error}</p>
+            <div>
+              <p className="text-sm font-semibold text-rose-600">
+                Esta posición tiene {position.empleados.length} empleados enlazados.
+              </p>
+              <p className="text-xs text-rose-400 mt-0.5">
+                Todos los empleados enlazados deben ser reasignados antes de eliminar esta posición.
+              </p>
+            </div>
           </div>
         )}
 
         {/* Botones */}
         <div className="flex items-center justify-end gap-3 pt-1">
           <button
-            onClick={onClose}
-            disabled={eliminando}
-            className="px-4 py-2 text-sm text-[#8aa3ad] hover:text-[#0F1819] border border-[#d1dde2] rounded-lg transition-colors disabled:opacity-60"
+            onClick={onCerrar}
+            className="px-4 py-2 text-sm text-[#8aa3ad] hover:text-[#0F1819] border border-[#d1dde2] rounded-lg transition-colors"
           >
             Cancelar
           </button>
@@ -81,6 +86,7 @@ export default function DeletePositionModal({
             {eliminando ? "Eliminando..." : "Eliminar Posición"}
           </button>
         </div>
+
       </div>
     </div>
   );


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el modal de confirmación visual para eliminar una posición, reemplazando el `window.confirm` nativo que existía anteriormente.

## Archivos creados/modificados
- `components/areas/positions/DeletePositionModal.tsx` — modal de confirmación con advertencia de empleados enlazados
- `app/dashboard/areas/positions/page.tsx` — integración del modal reemplazando `window.confirm`

## Decisiones técnicas
- El modal sigue el mismo estilo visual que `DeleteAreaModal` existente para mantener consistencia
- El modal maneja su propio estado de carga internamente
- Se agregó `data-menu-trigger` al dropdown para evitar que el listener de `mousedown` interceptara el click antes de abrir el modal
- Si la posición tiene empleados enlazados, se muestra una advertencia visual en el modal

## Pendiente
- El mensaje de confirmación de éxito tras eliminar queda pendiente de implementar — corresponde a **Jose Daniel Arango Reina** según el issue #45