### PR TITLE
Feat: agregar opción ver detalles con modal en panel de posiciones

### DIFF
--- a/app/dashboard/areas/positions/page.tsx
+++ b/app/dashboard/areas/positions/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ViewPositionModal from "@/components/areas/positions/viewPositionModal";
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
   ChevronRight,
@@ -10,6 +11,7 @@ import {
   X,
   Pencil,
   Trash2,
+  Eye,
   Plus,
 } from "lucide-react";
 import {
@@ -292,6 +294,8 @@ function NewPositionModal({
 // ─────────────────────────────────────────────────────────────────────────────
 
 export default function PositionsPage() {
+  const [posicionAVer, setPosicionAVer] = useState<Position | null>(null); //Nuevos estados
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null); //Nuevos estados
   const [positions, setPositions] = useState<Position[]>([]);
   const [activeTab, setActiveTab] = useState<ActiveTab>("All");
   const [search, setSearch] = useState("");
@@ -397,7 +401,7 @@ export default function PositionsPage() {
     }
   };
 
-  return (
+return (
     <div className="min-h-screen bg-[#ECEFF1]">
       {/* Header */}
       <div className="bg-white border-b border-[#BDD5EA]">
@@ -409,7 +413,6 @@ export default function PositionsPage() {
             <ChevronRight className="w-4 h-4" />
             <span className="text-[#0F1819] font-medium">Posiciones</span>
           </div>
-
           <div className="flex items-center justify-between">
             <h1 className="text-2xl font-bold text-[#0F1819]">
               Gestión de Posiciones
@@ -442,8 +445,8 @@ export default function PositionsPage() {
                 {tab === "All"
                   ? "Todas las Posiciones"
                   : tab === "Hierarchy"
-                    ? "Jerarquía"
-                    : "Archivadas"}
+                  ? "Jerarquía"
+                  : "Archivadas"}
               </button>
             ))}
           </div>
@@ -495,15 +498,13 @@ export default function PositionsPage() {
 
             {/* Table Body */}
             <div className="divide-y divide-[#BDD5EA]">
-              {positions.map((position, idx) => (
+              {positions.map((position) => (
                 <div
                   key={position.id}
                   className="grid grid-cols-12 gap-4 px-6 py-4 hover:bg-gray-50 transition-colors"
                 >
                   <div className="col-span-3">
-                    <p className="font-semibold text-[#0F1819]">
-                      {position.nombre}
-                    </p>
+                    <p className="font-semibold text-[#0F1819]">{position.nombre}</p>
                     <p className="text-xs text-[#8aa3ad]">{position.id}</p>
                   </div>
 
@@ -519,39 +520,23 @@ export default function PositionsPage() {
                     <StatusBadge status={position.estado} />
                   </div>
 
-                  <div className="col-span-2 relative">
+                  <div className="col-span-2">
                     <button
                       data-menu-trigger
-                      onClick={() =>
-                        setOpenMenuId(
-                          openMenuId === position.id ? null : position.id
-                        )
-                      }
+                      onClick={(e) => {
+                        if (openMenuId === position.id) {
+                          setOpenMenuId(null);
+                          setMenuPos(null);
+                        } else {
+                          const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                          setMenuPos({ top: rect.bottom + 4, left: rect.left - 120 });
+                          setOpenMenuId(position.id);
+                        }
+                      }}
                       className="p-2 hover:bg-gray-200 rounded-lg transition-colors"
                     >
                       <MoreVertical className="w-5 h-5 text-[#8aa3ad]" />
                     </button>
-
-                    {openMenuId === position.id && (
-                      <div
-                        ref={(el) => {
-                          if (el) menuRefs.current[position.id] = el;
-                        }}
-                        className="absolute right-0 mt-1 bg-white border border-[#BDD5EA] rounded-lg shadow-lg py-2 z-10 min-w-max"
-                      >
-                        <button className="w-full px-4 py-2 text-sm text-[#0F1819] hover:bg-gray-100 flex items-center gap-2 transition-colors">
-                          <Pencil className="w-4 h-4" />
-                          Editar
-                        </button>
-                        <button
-                          onClick={() => handleDeletePosition(position.id)}
-                          className="w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2 transition-colors"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                          Eliminar
-                        </button>
-                      </div>
-                    )}
                   </div>
                 </div>
               ))}
@@ -559,6 +544,42 @@ export default function PositionsPage() {
           </>
         )}
       </div>
+
+      {/* Dropdown flotante — fuera de la tabla para evitar overflow-hidden */}
+      {openMenuId && menuPos && (
+        <div
+          data-menu-trigger
+          className="fixed bg-white border border-[#BDD5EA] rounded-lg shadow-lg py-2 z-50 min-w-max"
+          style={{ top: menuPos.top, left: menuPos.left }}
+        >
+          <button
+            onClick={() => {
+              const pos = positions.find((p) => p.id === openMenuId);
+              if (pos) {
+                setOpenMenuId(null);
+                setMenuPos(null);
+                setPosicionAVer(pos);
+              }
+            }}
+            className="w-full px-4 py-2 text-sm text-[#0F1819] hover:bg-gray-100 flex items-center gap-2 transition-colors"
+          >
+            <Eye className="w-4 h-4" />
+            Ver detalles
+          </button>
+          <button
+            className="w-full px-4 py-2 text-sm text-[#0F1819] hover:bg-gray-100 flex items-center gap-2 transition-colors"
+          >
+            <Pencil className="w-4 h-4" />
+            Editar
+          </button>
+          <button
+            className="w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2 transition-colors"
+          >
+            <Trash2 className="w-4 h-4" />
+            Eliminar
+          </button>
+        </div>
+      )}
 
       {/* Pagination */}
       {!loading && positions.length > 0 && totalPages > 1 && (
@@ -606,12 +627,18 @@ export default function PositionsPage() {
         />
       )}
 
-      {/* New Position Modal */}
+      {/* Modales */}
       <NewPositionModal
         isOpen={showNewModal}
         onClose={() => setShowNewModal(false)}
         onSave={handleNewPosition}
         isLoading={modalLoading}
+      />
+
+      <ViewPositionModal
+        isOpen={posicionAVer !== null}
+        position={posicionAVer}
+        onCerrar={() => setPosicionAVer(null)}
       />
     </div>
   );

--- a/components/areas/positions/viewPositionModal.tsx
+++ b/components/areas/positions/viewPositionModal.tsx
@@ -1,0 +1,139 @@
+// components/areas/positions/ViewPositionModal.tsx
+"use client";
+
+import React from "react";
+import { X, Briefcase, Users, GitBranch, Calendar, Activity, Building2 } from "lucide-react";
+import { Position } from "@/services/positionsService";
+import { LucideIcon } from "lucide-react";
+
+interface ViewPositionModalProps {
+  position: Position | null;
+  isOpen: boolean;
+  onCerrar: () => void;
+}
+
+const BADGE_ESTADO: Record<string, string> = {
+  Active:   "bg-emerald-100 text-emerald-700",
+  Drafting: "bg-amber-100 text-amber-700",
+};
+
+const AREA_NOMBRES: Record<string, string> = {
+  "area-1": "Tecnología",
+  "area-2": "Seguridad",
+  "area-3": "Producto",
+  "area-4": "Diseño",
+  "area-5": "Datos",
+};
+
+// Fecha simulada — reemplazar con dato real cuando exista backend
+const FECHA_CREACION_SIMULADA = "15 Mar, 2023";
+
+interface FilaDetalleProps {
+  icono: LucideIcon;
+  etiqueta: string;
+  valor: string | number;
+}
+
+function FilaDetalle({ icono: Icono, etiqueta, valor }: FilaDetalleProps) {
+  return (
+    <div className="flex items-center gap-3 py-3 border-b border-[#f0f4f5] last:border-0">
+      <div className="w-8 h-8 rounded-lg bg-[#f4f7f8] flex items-center justify-center shrink-0">
+        <Icono size={15} className="text-[#203D47]" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-[10px] uppercase tracking-widest text-[#8aa3ad] font-semibold">
+          {etiqueta}
+        </p>
+        <p className="text-sm font-medium text-[#0F1819] mt-0.5">{valor}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function ViewPositionModal({
+  position,
+  isOpen,
+  onCerrar,
+}: ViewPositionModalProps) {
+  if (!isOpen || !position) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4">
+
+        {/* Encabezado */}
+        <div className="flex items-center justify-between px-6 py-5 border-b border-[#f0f4f5]">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-lg bg-[#203D47]/10 flex items-center justify-center shrink-0">
+              <Briefcase size={16} className="text-[#203D47]" />
+            </div>
+            <div>
+              <h2 className="text-base font-semibold text-[#0F1819]">{position.nombre}</h2>
+              <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${BADGE_ESTADO[position.estado]}`}>
+                {position.estado}
+              </span>
+            </div>
+          </div>
+          <button
+            onClick={onCerrar}
+            className="p-1.5 text-[#8aa3ad] hover:text-[#0F1819] hover:bg-[#f4f7f8] rounded-lg transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* ID de la posición */}
+        <div className="px-6 pt-5 pb-2">
+          <p className="text-[10px] uppercase tracking-widest text-[#8aa3ad] font-semibold mb-1">
+            Identificador
+          </p>
+          <p className="text-sm font-mono text-[#203D47]">{position.id}</p>
+        </div>
+
+        {/* Detalles */}
+        <div className="px-6 py-2">
+          <FilaDetalle
+            icono={Building2}
+            etiqueta="Área"
+            valor={AREA_NOMBRES[position.areaId] ?? position.areaId}
+          />
+          <FilaDetalle
+            icono={GitBranch}
+            etiqueta="Posición Superior"
+            valor={position.posicionSuperior ?? "Sin posición superior"}
+          />
+          <FilaDetalle
+            icono={Users}
+            etiqueta="Empleados asignados"
+            valor={
+              position.empleados.length > 0
+                ? position.empleados.map((e) => e.nombre).join(", ")
+                : "Sin empleados asignados"
+            }
+          />
+          <FilaDetalle
+            icono={Activity}
+            etiqueta="Estado"
+            valor={position.estado}
+          />
+          <FilaDetalle
+            icono={Calendar}
+            etiqueta="Fecha de creación"
+            valor={FECHA_CREACION_SIMULADA}
+          />
+        </div>
+
+        {/* Botón cerrar */}
+        <div className="flex justify-end px-6 pb-6 pt-2">
+          <button
+            onClick={onCerrar}
+            className="px-4 py-2 text-sm text-[#8aa3ad] hover:text-[#0F1819] border border-[#d1dde2] rounded-lg transition-colors"
+          >
+            Cerrar
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la opción "Ver detalles" en el menú de acciones del panel de posiciones, abriendo un modal con la información completa de la posición seleccionada.

## Archivos creados/modificados
- `components/areas/positions/ViewPositionModal.tsx` — modal de detalles con información de la posición (empleados, área, posición superior, estado, fecha de creación)
- `app/dashboard/areas/positions/page.tsx` — integración del modal y corrección del menú de acciones

## Cambios técnicos
- Se agregó la opción "Ver detalles" en el menú de acciones de cada fila
- El dropdown ahora usa `position: fixed` con coordenadas calculadas dinámicamente desde el botón, lo que resuelve el problema donde el menú se ocultaba por el `overflow-hidden` del contenedor de la tabla
- Los estados `posicionAVer`, `setPosicionAVer`, `menuPos` y `setMenuPos` fueron agregados para manejar el modal y la posición del dropdown
- Los datos del modal son simulados, listos para conectar con backend

## ⚠️ Revisión requerida antes del merge

- **Issue #38 — Eliminar posición**: ese issue modifica el mismo `page.tsx` y el dropdown de acciones. Al fusionar, verificar que el `onClick` del botón "Eliminar" en el dropdown flotante quede conectado con `handleAbrirEliminar(pos)` correctamente.

- **Issue #46 — Editar posición**: aún no está implementado. El botón "Editar" en el dropdown existe pero sin `onClick`. Al implementarse, debe conectarse al handler correspondiente en el mismo dropdown flotante.